### PR TITLE
Moved Models, Inference & Algorithms to general

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,9 @@ In general the following are excellent resources:
 + [VideoLectures.NET](http://videolectures.net/) is the primary video archive for machine learning. Much of its content focuses on the field, incorporating conferences, workshops, lectures, and even discussions.
 + [TechTalks.tv](http://techtalks.tv/) is the second most used archive. Notably, many ICML videos are located here.
 + [Youtube](http://youtube.com/) contains a few, such as certain AISTATS and ICLR years. It's best for collecting lectures, such as by [Nando de Freitas](https://www.youtube.com/playlist?list=PLE6Wd9FR--EfW8dtjAuPoTuPcqmOV53Fu) and [Alex Smola](https://www.youtube.com/playlist?list=PLZSO_6-bSqHTTV7w9u7grTXBHMH-mw3qn). Also, the user [mathematicalmonk](https://www.youtube.com/user/mathematicalmonk) has created several basic mathematical and probability overviews for many [ML methods](https://www.youtube.com/playlist?list=PLD0F06AA0D2E8FFBA).
++ [Models, Inference, & Algorithms](https://www.broadinstitute.org/scientific-community/science/mia/models-inference-algorithms) at the Broad Institute of MIT and Harvard has slide decks and a growing [playlist](https://www.youtube.com/playlist?list=PLlMMtlgw6qNjROoMNTBQjAcdx53kV50cS) on machine learning for biomedical research.
 
 ## 2017
-
-+ [Broad Institute Seminar: Models, Inference, & Algorithms](https://www.broadinstitute.org/scientific-community/science/mia/models-inference-algorithms)
 + [GPU Technology Conference](http://on-demand-gtc.gputechconf.com/gtc-quicklink/g6VqzTi)
 + [Data Learning and Inference Workshop, Data Efficient Reinforcement Learning](https://www.youtube.com/playlist?list=PL-tWvTpyd1VAvDpxukup6w-SuZQQ7e8K8)
 + [Edinburgh Deep Learning Workshop](http://workshops.inf.ed.ac.uk/deep/deep2017/)


### PR DESCRIPTION
We started in 2015 and will keep adding at least a dozen primer-seminar videos per term.